### PR TITLE
Run base image with RUST_BACKTRACE on

### DIFF
--- a/base-build/Dockerfile
+++ b/base-build/Dockerfile
@@ -34,6 +34,7 @@ RUN sed -i 's/.*cuckoo_miner_plugin_dir.*/cuckoo_miner_plugin_dir = "\/usr\/lib\
 RUN chown -R grinuser:grinuser /home/grinuser/.grin
 USER grinuser
 WORKDIR /home/grinuser
+ENV RUST_BACKTRACE=1
 RUN grin wallet init
 ENTRYPOINT ["/usr/bin/grin"]
 # forward log to docker log collector


### PR DESCRIPTION
Useful to have on by default since this is still experimental stuff and people are going to open issue reports that do not provide enough info.