### PR TITLE
Add Clang to docker build for compiling dependency

### DIFF
--- a/base-build/Dockerfile
+++ b/base-build/Dockerfile
@@ -6,7 +6,7 @@
 #use official rust docker image (debian based)
 FROM rust:1.21-stretch as grin_build
 #needs cmake
-RUN apt-get update && apt-get -y install cmake
+RUN apt-get update && apt-get -y install cmake clang
 #checkout source fresh and build
 WORKDIR /usr/src
 RUN git clone https://github.com/mimblewimble/grin.git

--- a/base-build/Dockerfile.botnet
+++ b/base-build/Dockerfile.botnet
@@ -6,7 +6,7 @@
 #use official rust docker image (debian based)
 FROM rust:1.21-stretch as grin_build
 #needs cmake, node packages (for controller)
-RUN apt-get update && apt-get -y install cmake
+RUN apt-get update && apt-get -y install cmake clang
 #checkout source fresh and build
 WORKDIR /usr/src
 RUN git clone https://github.com/mimblewimble/grin.git


### PR DESCRIPTION
[librocksdb-sys](https://github.com/spacejam/rust-rocksdb/tree/master/librocksdb-sys) requires libclang for compilation.

Note that this only fixes the image build. The wallet images are failing due to
https://github.com/mimblewimble/grin/blob/81c41449d551fdf8bb127f7699b271df1f2146c7/src/bin/grin.rs#L460

I'm interested in fixing the docker-compose run, but I'm not sure what command to run for the wallets.